### PR TITLE
chore(darwin): use .app instead of .App for executable

### DIFF
--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,0 +1,3 @@
+
+# Set eol to LF so files aren't converted to CRLF-eol on Windows.
+* text eol=lf

--- a/esy.lock/.gitignore
+++ b/esy.lock/.gitignore
@@ -1,0 +1,3 @@
+
+# Reset any possible .gitignore, we want all esy.lock to be un-ignored.
+!*

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,0 +1,1210 @@
+{
+  "checksum": "d500582bee546cc7cbf6c4ef6a3bdaa0",
+  "root": "revery-packager@link-dev:./package.json",
+  "node": {
+    "zip-stream@2.1.2@d41d8cd9": {
+      "id": "zip-stream@2.1.2@d41d8cd9",
+      "name": "zip-stream",
+      "version": "2.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz#sha1:841efd23214b602ff49c497cba1a85d8b5fbc39c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "readable-stream@3.4.0@d41d8cd9", "compress-commons@2.1.1@d41d8cd9",
+        "archiver-utils@2.1.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "zip-a-folder@0.0.9@d41d8cd9": {
+      "id": "zip-a-folder@0.0.9@d41d8cd9",
+      "name": "zip-a-folder",
+      "version": "0.0.9",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/zip-a-folder/-/zip-a-folder-0.0.9.tgz#sha1:c2960e529a92a87f2b5bbd519f5a23db0475165e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "archiver@3.1.1@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "yargs-parser@15.0.0@d41d8cd9": {
+      "id": "yargs-parser@15.0.0@d41d8cd9",
+      "name": "yargs-parser",
+      "version": "15.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz#sha1:cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "decamelize@1.2.0@d41d8cd9", "camelcase@5.3.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "yargs@14.2.1@d41d8cd9": {
+      "id": "yargs@14.2.1@d41d8cd9",
+      "name": "yargs",
+      "version": "14.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/yargs/-/yargs-14.2.1.tgz#sha1:2bb87b57c12b9afea40bb4ed9745bb9eb5031a9b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "yargs-parser@15.0.0@d41d8cd9", "y18n@4.0.0@d41d8cd9",
+        "which-module@2.0.0@d41d8cd9", "string-width@3.1.0@d41d8cd9",
+        "set-blocking@2.0.0@d41d8cd9",
+        "require-main-filename@2.0.0@d41d8cd9",
+        "require-directory@2.1.1@d41d8cd9", "get-caller-file@2.0.5@d41d8cd9",
+        "find-up@3.0.0@d41d8cd9", "decamelize@1.2.0@d41d8cd9",
+        "cliui@5.0.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "y18n@4.0.0@d41d8cd9": {
+      "id": "y18n@4.0.0@d41d8cd9",
+      "name": "y18n",
+      "version": "4.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz#sha1:95ef94f85ecc81d007c264e190a120f0a3c8566b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "xmldom@0.1.27@d41d8cd9": {
+      "id": "xmldom@0.1.27@d41d8cd9",
+      "name": "xmldom",
+      "version": "0.1.27",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz#sha1:d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "xmlbuilder@9.0.7@d41d8cd9": {
+      "id": "xmlbuilder@9.0.7@d41d8cd9",
+      "name": "xmlbuilder",
+      "version": "9.0.7",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz#sha1:132ee63d2ec5565c557e20f4c22df9aca686b10d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "wrappy@1.0.2@d41d8cd9": {
+      "id": "wrappy@1.0.2@d41d8cd9",
+      "name": "wrappy",
+      "version": "1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#sha1:b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "wrap-ansi@5.1.0@d41d8cd9": {
+      "id": "wrap-ansi@5.1.0@d41d8cd9",
+      "name": "wrap-ansi",
+      "version": "5.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz#sha1:1fd1f67235d5b6d0fee781056001bfb694c03b09"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "strip-ansi@5.2.0@d41d8cd9", "string-width@3.1.0@d41d8cd9",
+        "ansi-styles@3.2.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "which-module@2.0.0@d41d8cd9": {
+      "id": "which-module@2.0.0@d41d8cd9",
+      "name": "which-module",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#sha1:d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "util-deprecate@1.0.2@d41d8cd9": {
+      "id": "util-deprecate@1.0.2@d41d8cd9",
+      "name": "util-deprecate",
+      "version": "1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#sha1:450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "universalify@0.1.2@d41d8cd9": {
+      "id": "universalify@0.1.2@d41d8cd9",
+      "name": "universalify",
+      "version": "0.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#sha1:b646f69be3942dabcecc9d6639c80dc105efaa66"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "tar-stream@2.1.0@d41d8cd9": {
+      "id": "tar-stream@2.1.0@d41d8cd9",
+      "name": "tar-stream",
+      "version": "2.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz#sha1:d1aaa3661f05b38b5acc9b7020efdca5179a2cc3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "readable-stream@3.4.0@d41d8cd9", "inherits@2.0.4@d41d8cd9",
+        "fs-constants@1.0.0@d41d8cd9", "end-of-stream@1.4.4@d41d8cd9",
+        "bl@3.0.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "strip-ansi@5.2.0@d41d8cd9": {
+      "id": "strip-ansi@5.2.0@d41d8cd9",
+      "name": "strip-ansi",
+      "version": "5.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz#sha1:8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "ansi-regex@4.1.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "string_decoder@1.3.0@d41d8cd9": {
+      "id": "string_decoder@1.3.0@d41d8cd9",
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz#sha1:42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "safe-buffer@5.2.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "string_decoder@1.1.1@d41d8cd9": {
+      "id": "string_decoder@1.1.1@d41d8cd9",
+      "name": "string_decoder",
+      "version": "1.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#sha1:9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "safe-buffer@5.1.2@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "string-width@3.1.0@d41d8cd9": {
+      "id": "string-width@3.1.0@d41d8cd9",
+      "name": "string-width",
+      "version": "3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz#sha1:22767be21b62af1081574306f69ac51b62203961"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "strip-ansi@5.2.0@d41d8cd9",
+        "is-fullwidth-code-point@2.0.0@d41d8cd9",
+        "emoji-regex@7.0.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "set-blocking@2.0.0@d41d8cd9": {
+      "id": "set-blocking@2.0.0@d41d8cd9",
+      "name": "set-blocking",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#sha1:045f9782d011ae9a6803ddd382b24392b3d890f7"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "safe-buffer@5.2.0@d41d8cd9": {
+      "id": "safe-buffer@5.2.0@d41d8cd9",
+      "name": "safe-buffer",
+      "version": "5.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz#sha1:b74daec49b1148f88c64b68d49b1e815c1f2f519"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "safe-buffer@5.1.2@d41d8cd9": {
+      "id": "safe-buffer@5.1.2@d41d8cd9",
+      "name": "safe-buffer",
+      "version": "5.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#sha1:991ec69d296e0313747d59bdfd2b745c35f8828d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "revery-packager@link-dev:./package.json": {
+      "id": "revery-packager@link-dev:./package.json",
+      "name": "revery-packager",
+      "version": "link-dev:./package.json",
+      "source": {
+        "type": "link-dev",
+        "path": ".",
+        "manifest": "package.json"
+      },
+      "overrides": [],
+      "dependencies": [
+        "zip-a-folder@0.0.9@d41d8cd9", "yargs@14.2.1@d41d8cd9",
+        "plist@3.0.1@d41d8cd9", "fs-extra@8.1.0@d41d8cd9",
+        "esy-macdylibbundler@0.4.5@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "require-main-filename@2.0.0@d41d8cd9": {
+      "id": "require-main-filename@2.0.0@d41d8cd9",
+      "name": "require-main-filename",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz#sha1:d0b329ecc7cc0f61649f62215be69af54aa8989b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "require-directory@2.1.1@d41d8cd9": {
+      "id": "require-directory@2.1.1@d41d8cd9",
+      "name": "require-directory",
+      "version": "2.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#sha1:8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "readable-stream@3.4.0@d41d8cd9": {
+      "id": "readable-stream@3.4.0@d41d8cd9",
+      "name": "readable-stream",
+      "version": "3.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz#sha1:a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "util-deprecate@1.0.2@d41d8cd9", "string_decoder@1.3.0@d41d8cd9",
+        "inherits@2.0.4@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "readable-stream@2.3.6@d41d8cd9": {
+      "id": "readable-stream@2.3.6@d41d8cd9",
+      "name": "readable-stream",
+      "version": "2.3.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#sha1:b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "util-deprecate@1.0.2@d41d8cd9", "string_decoder@1.1.1@d41d8cd9",
+        "safe-buffer@5.1.2@d41d8cd9", "process-nextick-args@2.0.1@d41d8cd9",
+        "isarray@1.0.0@d41d8cd9", "inherits@2.0.4@d41d8cd9",
+        "core-util-is@1.0.2@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "process-nextick-args@2.0.1@d41d8cd9": {
+      "id": "process-nextick-args@2.0.1@d41d8cd9",
+      "name": "process-nextick-args",
+      "version": "2.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz#sha1:7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "plist@3.0.1@d41d8cd9": {
+      "id": "plist@3.0.1@d41d8cd9",
+      "name": "plist",
+      "version": "3.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/plist/-/plist-3.0.1.tgz#sha1:a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "xmldom@0.1.27@d41d8cd9", "xmlbuilder@9.0.7@d41d8cd9",
+        "base64-js@1.3.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "path-is-absolute@1.0.1@d41d8cd9": {
+      "id": "path-is-absolute@1.0.1@d41d8cd9",
+      "name": "path-is-absolute",
+      "version": "1.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#sha1:174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "path-exists@3.0.0@d41d8cd9": {
+      "id": "path-exists@3.0.0@d41d8cd9",
+      "name": "path-exists",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz#sha1:ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "p-try@2.2.0@d41d8cd9": {
+      "id": "p-try@2.2.0@d41d8cd9",
+      "name": "p-try",
+      "version": "2.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#sha1:cb2868540e313d61de58fafbe35ce9004d5540e6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "p-locate@3.0.0@d41d8cd9": {
+      "id": "p-locate@3.0.0@d41d8cd9",
+      "name": "p-locate",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz#sha1:322d69a05c0264b25997d9f40cd8a891ab0064a4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "p-limit@2.2.1@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "p-limit@2.2.1@d41d8cd9": {
+      "id": "p-limit@2.2.1@d41d8cd9",
+      "name": "p-limit",
+      "version": "2.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz#sha1:aa07a788cc3151c939b5131f63570f0dd2009537"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "p-try@2.2.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "once@1.4.0@d41d8cd9": {
+      "id": "once@1.4.0@d41d8cd9",
+      "name": "once",
+      "version": "1.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/once/-/once-1.4.0.tgz#sha1:583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "wrappy@1.0.2@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "normalize-path@3.0.0@d41d8cd9": {
+      "id": "normalize-path@3.0.0@d41d8cd9",
+      "name": "normalize-path",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz#sha1:0dcd69ff23a1c9b11fd0978316644a0388216a65"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "minimatch@3.0.4@d41d8cd9": {
+      "id": "minimatch@3.0.4@d41d8cd9",
+      "name": "minimatch",
+      "version": "3.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#sha1:5166e286457f03306064be5497e8dbb0c3d32083"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "brace-expansion@1.1.11@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "lodash.union@4.6.0@d41d8cd9": {
+      "id": "lodash.union@4.6.0@d41d8cd9",
+      "name": "lodash.union",
+      "version": "4.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz#sha1:48bb5088409f16f1821666641c44dd1aaae3cd88"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "lodash.isplainobject@4.0.6@d41d8cd9": {
+      "id": "lodash.isplainobject@4.0.6@d41d8cd9",
+      "name": "lodash.isplainobject",
+      "version": "4.0.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#sha1:7c526a52d89b45c45cc690b88163be0497f550cb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "lodash.flatten@4.4.0@d41d8cd9": {
+      "id": "lodash.flatten@4.4.0@d41d8cd9",
+      "name": "lodash.flatten",
+      "version": "4.4.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz#sha1:f31c22225a9632d2bbf8e4addbef240aa765a61f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "lodash.difference@4.5.0@d41d8cd9": {
+      "id": "lodash.difference@4.5.0@d41d8cd9",
+      "name": "lodash.difference",
+      "version": "4.5.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz#sha1:9ccb4e505d486b91651345772885a2df27fd017c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "lodash.defaults@4.2.0@d41d8cd9": {
+      "id": "lodash.defaults@4.2.0@d41d8cd9",
+      "name": "lodash.defaults",
+      "version": "4.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz#sha1:d09178716ffea4dde9e5fb7b37f6f0802274580c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "lodash@4.17.15@d41d8cd9": {
+      "id": "lodash@4.17.15@d41d8cd9",
+      "name": "lodash",
+      "version": "4.17.15",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#sha1:b447f6670a0455bbfeedd11392eff330ea097548"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "locate-path@3.0.0@d41d8cd9": {
+      "id": "locate-path@3.0.0@d41d8cd9",
+      "name": "locate-path",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz#sha1:dbec3b3ab759758071b58fe59fc41871af21400e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "path-exists@3.0.0@d41d8cd9", "p-locate@3.0.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "lazystream@1.0.0@d41d8cd9": {
+      "id": "lazystream@1.0.0@d41d8cd9",
+      "name": "lazystream",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz#sha1:f6995fe0f820392f61396be89462407bb77168e4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "readable-stream@2.3.6@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "jsonfile@4.0.0@d41d8cd9": {
+      "id": "jsonfile@4.0.0@d41d8cd9",
+      "name": "jsonfile",
+      "version": "4.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz#sha1:8771aae0799b64076b76640fca058f9c10e33ecb"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "graceful-fs@4.2.3@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "isarray@1.0.0@d41d8cd9": {
+      "id": "isarray@1.0.0@d41d8cd9",
+      "name": "isarray",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#sha1:bb935d48582cba168c06834957a54a3e07124f11"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "is-fullwidth-code-point@2.0.0@d41d8cd9": {
+      "id": "is-fullwidth-code-point@2.0.0@d41d8cd9",
+      "name": "is-fullwidth-code-point",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#sha1:a3b30a5c4f199183167aaab93beefae3ddfb654f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "inherits@2.0.4@d41d8cd9": {
+      "id": "inherits@2.0.4@d41d8cd9",
+      "name": "inherits",
+      "version": "2.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#sha1:0fa2c64f932917c3433a0ded55363aae37416b7c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "inflight@1.0.6@d41d8cd9": {
+      "id": "inflight@1.0.6@d41d8cd9",
+      "name": "inflight",
+      "version": "1.0.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz#sha1:49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "wrappy@1.0.2@d41d8cd9", "once@1.4.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "ieee754@1.1.13@d41d8cd9": {
+      "id": "ieee754@1.1.13@d41d8cd9",
+      "name": "ieee754",
+      "version": "1.1.13",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz#sha1:ec168558e95aa181fd87d37f55c32bbcb6708b84"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "graceful-fs@4.2.3@d41d8cd9": {
+      "id": "graceful-fs@4.2.3@d41d8cd9",
+      "name": "graceful-fs",
+      "version": "4.2.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz#sha1:4a12ff1b60376ef09862c2093edd908328be8423"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "glob@7.1.6@d41d8cd9": {
+      "id": "glob@7.1.6@d41d8cd9",
+      "name": "glob",
+      "version": "7.1.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#sha1:141f33b81a7c2492e125594307480c46679278a6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "path-is-absolute@1.0.1@d41d8cd9", "once@1.4.0@d41d8cd9",
+        "minimatch@3.0.4@d41d8cd9", "inherits@2.0.4@d41d8cd9",
+        "inflight@1.0.6@d41d8cd9", "fs.realpath@1.0.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "get-caller-file@2.0.5@d41d8cd9": {
+      "id": "get-caller-file@2.0.5@d41d8cd9",
+      "name": "get-caller-file",
+      "version": "2.0.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz#sha1:4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "fs.realpath@1.0.0@d41d8cd9": {
+      "id": "fs.realpath@1.0.0@d41d8cd9",
+      "name": "fs.realpath",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#sha1:1504ad2523158caa40db4a2787cb01411994ea4f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "fs-extra@8.1.0@d41d8cd9": {
+      "id": "fs-extra@8.1.0@d41d8cd9",
+      "name": "fs-extra",
+      "version": "8.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz#sha1:49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "universalify@0.1.2@d41d8cd9", "jsonfile@4.0.0@d41d8cd9",
+        "graceful-fs@4.2.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "fs-constants@1.0.0@d41d8cd9": {
+      "id": "fs-constants@1.0.0@d41d8cd9",
+      "name": "fs-constants",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz#sha1:6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "find-up@3.0.0@d41d8cd9": {
+      "id": "find-up@3.0.0@d41d8cd9",
+      "name": "find-up",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz#sha1:49169f1d7993430646da61ecc5ae355c21c97b73"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "locate-path@3.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "esy-macdylibbundler@0.4.5@d41d8cd9": {
+      "id": "esy-macdylibbundler@0.4.5@d41d8cd9",
+      "name": "esy-macdylibbundler",
+      "version": "0.4.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esy-macdylibbundler/-/esy-macdylibbundler-0.4.5.tgz#sha1:f4aeadafe072b8fce9603a6da3cd10fa15c23495"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "esy-cmake@0.3.5@d41d8cd9": {
+      "id": "esy-cmake@0.3.5@d41d8cd9",
+      "name": "esy-cmake",
+      "version": "0.3.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esy-cmake/-/esy-cmake-0.3.5.tgz#sha1:2df0bdfe9317fbcded5f463fca1f346464494c7a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "end-of-stream@1.4.4@d41d8cd9": {
+      "id": "end-of-stream@1.4.4@d41d8cd9",
+      "name": "end-of-stream",
+      "version": "1.4.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz#sha1:5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "once@1.4.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "emoji-regex@7.0.3@d41d8cd9": {
+      "id": "emoji-regex@7.0.3@d41d8cd9",
+      "name": "emoji-regex",
+      "version": "7.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz#sha1:933a04052860c85e83c122479c4748a8e4c72156"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "decamelize@1.2.0@d41d8cd9": {
+      "id": "decamelize@1.2.0@d41d8cd9",
+      "name": "decamelize",
+      "version": "1.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#sha1:f6534d15148269b20352e7bee26f501f9a191290"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "crc32-stream@3.0.1@d41d8cd9": {
+      "id": "crc32-stream@3.0.1@d41d8cd9",
+      "name": "crc32-stream",
+      "version": "3.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz#sha1:cae6eeed003b0e44d739d279de5ae63b171b4e85"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "readable-stream@3.4.0@d41d8cd9", "crc@3.8.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "crc@3.8.0@d41d8cd9": {
+      "id": "crc@3.8.0@d41d8cd9",
+      "name": "crc",
+      "version": "3.8.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/crc/-/crc-3.8.0.tgz#sha1:ad60269c2c856f8c299e2c4cc0de4556914056c6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "buffer@5.4.3@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "core-util-is@1.0.2@d41d8cd9": {
+      "id": "core-util-is@1.0.2@d41d8cd9",
+      "name": "core-util-is",
+      "version": "1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#sha1:b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "concat-map@0.0.1@d41d8cd9": {
+      "id": "concat-map@0.0.1@d41d8cd9",
+      "name": "concat-map",
+      "version": "0.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#sha1:d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "compress-commons@2.1.1@d41d8cd9": {
+      "id": "compress-commons@2.1.1@d41d8cd9",
+      "name": "compress-commons",
+      "version": "2.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz#sha1:9410d9a534cf8435e3fbbb7c6ce48de2dc2f0610"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "readable-stream@2.3.6@d41d8cd9", "normalize-path@3.0.0@d41d8cd9",
+        "crc32-stream@3.0.1@d41d8cd9", "buffer-crc32@0.2.13@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "color-name@1.1.3@d41d8cd9": {
+      "id": "color-name@1.1.3@d41d8cd9",
+      "name": "color-name",
+      "version": "1.1.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz#sha1:a7d0558bd89c42f795dd42328f740831ca53bc25"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "color-convert@1.9.3@d41d8cd9": {
+      "id": "color-convert@1.9.3@d41d8cd9",
+      "name": "color-convert",
+      "version": "1.9.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz#sha1:bb71850690e1f136567de629d2d5471deda4c1e8"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "color-name@1.1.3@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "cliui@5.0.0@d41d8cd9": {
+      "id": "cliui@5.0.0@d41d8cd9",
+      "name": "cliui",
+      "version": "5.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz#sha1:deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "wrap-ansi@5.1.0@d41d8cd9", "strip-ansi@5.2.0@d41d8cd9",
+        "string-width@3.1.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "camelcase@5.3.1@d41d8cd9": {
+      "id": "camelcase@5.3.1@d41d8cd9",
+      "name": "camelcase",
+      "version": "5.3.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#sha1:e3c9b31569e106811df242f715725a1f4c494320"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "buffer-crc32@0.2.13@d41d8cd9": {
+      "id": "buffer-crc32@0.2.13@d41d8cd9",
+      "name": "buffer-crc32",
+      "version": "0.2.13",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz#sha1:0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "buffer@5.4.3@d41d8cd9": {
+      "id": "buffer@5.4.3@d41d8cd9",
+      "name": "buffer",
+      "version": "5.4.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz#sha1:3fbc9c69eb713d323e3fc1a895eee0710c072115"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ieee754@1.1.13@d41d8cd9", "base64-js@1.3.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "brace-expansion@1.1.11@d41d8cd9": {
+      "id": "brace-expansion@1.1.11@d41d8cd9",
+      "name": "brace-expansion",
+      "version": "1.1.11",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#sha1:3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "concat-map@0.0.1@d41d8cd9", "balanced-match@1.0.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "bl@3.0.0@d41d8cd9": {
+      "id": "bl@3.0.0@d41d8cd9",
+      "name": "bl",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/bl/-/bl-3.0.0.tgz#sha1:3611ec00579fd18561754360b21e9f784500ff88"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "readable-stream@3.4.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "base64-js@1.3.1@d41d8cd9": {
+      "id": "base64-js@1.3.1@d41d8cd9",
+      "name": "base64-js",
+      "version": "1.3.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz#sha1:58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "balanced-match@1.0.0@d41d8cd9": {
+      "id": "balanced-match@1.0.0@d41d8cd9",
+      "name": "balanced-match",
+      "version": "1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#sha1:89b4d199ab2bee49de164ea02b89ce462d71b767"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "async@2.6.3@d41d8cd9": {
+      "id": "async@2.6.3@d41d8cd9",
+      "name": "async",
+      "version": "2.6.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/async/-/async-2.6.3.tgz#sha1:d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "lodash@4.17.15@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "archiver-utils@2.1.0@d41d8cd9": {
+      "id": "archiver-utils@2.1.0@d41d8cd9",
+      "name": "archiver-utils",
+      "version": "2.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz#sha1:e8a460e94b693c3e3da182a098ca6285ba9249e2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "readable-stream@2.3.6@d41d8cd9", "normalize-path@3.0.0@d41d8cd9",
+        "lodash.union@4.6.0@d41d8cd9", "lodash.isplainobject@4.0.6@d41d8cd9",
+        "lodash.flatten@4.4.0@d41d8cd9", "lodash.difference@4.5.0@d41d8cd9",
+        "lodash.defaults@4.2.0@d41d8cd9", "lazystream@1.0.0@d41d8cd9",
+        "graceful-fs@4.2.3@d41d8cd9", "glob@7.1.6@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "archiver@3.1.1@d41d8cd9": {
+      "id": "archiver@3.1.1@d41d8cd9",
+      "name": "archiver",
+      "version": "3.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz#sha1:9db7819d4daf60aec10fe86b16cb9258ced66ea0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "zip-stream@2.1.2@d41d8cd9", "tar-stream@2.1.0@d41d8cd9",
+        "readable-stream@3.4.0@d41d8cd9", "glob@7.1.6@d41d8cd9",
+        "buffer-crc32@0.2.13@d41d8cd9", "async@2.6.3@d41d8cd9",
+        "archiver-utils@2.1.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "ansi-styles@3.2.1@d41d8cd9": {
+      "id": "ansi-styles@3.2.1@d41d8cd9",
+      "name": "ansi-styles",
+      "version": "3.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#sha1:41fbb20243e50b12be0f04b8dedbf07520ce841d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "color-convert@1.9.3@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "ansi-regex@4.1.0@d41d8cd9": {
+      "id": "ansi-regex@4.1.0@d41d8cd9",
+      "name": "ansi-regex",
+      "version": "4.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz#sha1:8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    }
+  }
+}

--- a/src/package-darwin.js
+++ b/src/package-darwin.js
@@ -1,142 +1,146 @@
-const fs = require("fs-extra");
-const path = require("path");
+const fs = require("fs-extra");
+const path = require("path");
 const appdmg = require("appdmg");
-
-const util = require("./util");
-const esy = require("./esy");
-
-const makeDmg = async (spec) => {
-  return new Promise((resolve, reject) => {
+
+const util = require("./util");
+const esy = require("./esy");
+
+const makeDmg = async spec => {
+  return new Promise((resolve, reject) => {
     console.dir(spec);
-    const ee = appdmg(spec);
-
-    ee.on('progress', (info) => {
-      if (info.type == 'step-begin') {
-        console.log("[DMG] " + info.title);
-      }
-    });
-
-    ee.on('finish', () => {
-      resolve();
-    });
-
-    ee.on('error', (err) => {
-      reject(err);
-    });
-  });
-};
-
-module.exports = async (config) => {
-    const appName = config.bundleInfo.bundleName + ".App";
-    
-    console.log("Packaging for OSX: " + appName);
-    
-    // The MacOS app folder structure looks like this:
-    // - MyApp.App
-    //   - Contents
-    //     - Resources (non-executable resources)
-    //     - MacOS (executable reosurces)
-    //     - Frameworks (library code)
-
-    const appDirectory = path.join(config.platformReleaseDir, appName);
-    const contentsDirectory = path.join(appDirectory, "Contents");
-    const resourcesDirectory = path.join(contentsDirectory, "Resources");
-    const binaryDirectory = path.join(contentsDirectory, "MacOS");
-    const frameworksDirectory = path.join(contentsDirectory, "Frameworks");
-
-    const plistFile = path.join(contentsDirectory, "Info.plist");
-
-    fs.mkdirpSync(frameworksDirectory);
-    fs.mkdirpSync(resourcesDirectory);
-
-    const bundleInfo = config.bundleInfo;
-
-    // Create an Info.plist file for the app
-    const plistContents = {
-      CFBundleName: bundleInfo.bundleName,
-      CFBundleDisplayName: bundleInfo.displayName,
-      CFBundleIdentifier: bundleInfo.bundleId,
-      CFBundleIconFile: bundleInfo.iconFile,
-      CFBundleVersion: config.packageInfo.version,
-      CFBundlePackageType: "APPL",
-      CFBundleSignature: "????",
-      CFBundleExecutable: bundleInfo.mainExecutable,
-      NSHighResolutionCapable: true,
-    };
-
-    fs.writeFileSync(plistFile, require("plist").build(plistContents));
-
-    // Copy the bin folder over
-    util.copy(config.binPath, binaryDirectory);
-
-    // ...but move non-executables from the bin folder to the resources folder,
-    // but symlink in, so that the executables can pretend they are available
-
-    const filesToBeMoved = fs.readdirSync(binaryDirectory).filter((f) => {
-        return f != bundleInfo.mainExecutable;
-    });
-
-    filesToBeMoved.forEach((file) => {
-      console.log("Moving file: " + file);
-      const fileSrc = path.join(binaryDirectory, file);
-      const fileDest = path.join(resourcesDirectory, file);
-      console.log(`Moving file from ${fileSrc} to ${fileDest}.`);
-      fs.moveSync(fileSrc, fileDest);
-      const symlinkDest = path.join("../Resources", file);
-      console.log(`Symlinking ${symlinkDest} -> ${fileSrc}`);
-      fs.ensureSymlinkSync(symlinkDest, fileSrc);
-    });
-
-    console.log("Bundling dylibs...");
-
-    const executablePath = path.join(binaryDirectory, bundleInfo.mainExecutable);
-
-    // Run the 'dylibbundler' tool
-    util.shell(`${config.macBundlerPath} -b -x "${executablePath}" -d "${frameworksDirectory}" -p "@executable_path/../Frameworks/" -cd`);
-
-    // Bundle into tar package, if specified
-    if(config.bundleInfo.packages.indexOf("tar") >= 0) {
-      const tarDest = `${config.bundleInfo.bundleName}-darwin.tar.gz`;
-      util.shell(`cd '${config.platformReleaseDir}' && tar -zcf '../${tarDest}' ${appName}`);
-      console.log(`** Created tar package: ${tarDest}`);
-    }
-
-    // Create DMG package, if specified
-    if(config.bundleInfo.packages.indexOf("dmg") >= 0) { 
-      const dmgTarget = config.bundleInfo.bundleName + ".dmg";
-      const spec = {
-        target: path.join(config.releaseDir, dmgTarget),
-        basepath: config.platformReleaseDir,
-        specification: {
-          title: config.bundleInfo.displayName,
-          background: config.bundleInfo.dmgBackground,
-          format: "ULFO",
-          window: {
-              size: {
-                  width: 660,
-                  height: 400,
-              }
-          },
-          contents: [
-              {
-                  x: 180,
-                  y: 170,
-                  type: "file",
-                  path: appDirectory,
-              },
-              {
-                  x: 480,
-                  y: 170,
-                  type: "link",
-                  path: "/Applications"
-              }
-          ]
-        },
-      };
-
-      await makeDmg(spec);
-      console.log("** Created DMG: " + dmgTarget);
-    }
-
-    console.log("OSX packaging complete!");
-};
+    const ee = appdmg(spec);
+
+    ee.on("progress", info => {
+      if (info.type == "step-begin") {
+        console.log("[DMG] " + info.title);
+      }
+    });
+
+    ee.on("finish", () => {
+      resolve();
+    });
+
+    ee.on("error", err => {
+      reject(err);
+    });
+  });
+};
+
+module.exports = async config => {
+  const appName = config.bundleInfo.bundleName + ".app";
+
+  console.log("Packaging for OSX: " + appName);
+
+  // The MacOS app folder structure looks like this:
+  // - MyApp.app
+  //   - Contents
+  //     - Resources (non-executable resources)
+  //     - MacOS (executable reosurces)
+  //     - Frameworks (library code)
+
+  const appDirectory = path.join(config.platformReleaseDir, appName);
+  const contentsDirectory = path.join(appDirectory, "Contents");
+  const resourcesDirectory = path.join(contentsDirectory, "Resources");
+  const binaryDirectory = path.join(contentsDirectory, "MacOS");
+  const frameworksDirectory = path.join(contentsDirectory, "Frameworks");
+
+  const plistFile = path.join(contentsDirectory, "Info.plist");
+
+  fs.mkdirpSync(frameworksDirectory);
+  fs.mkdirpSync(resourcesDirectory);
+
+  const bundleInfo = config.bundleInfo;
+
+  // Create an Info.plist file for the app
+  const plistContents = {
+    CFBundleName: bundleInfo.bundleName,
+    CFBundleDisplayName: bundleInfo.displayName,
+    CFBundleIdentifier: bundleInfo.bundleId,
+    CFBundleIconFile: bundleInfo.iconFile,
+    CFBundleVersion: config.packageInfo.version,
+    CFBundlePackageType: "APPL",
+    CFBundleSignature: "????",
+    CFBundleExecutable: bundleInfo.mainExecutable,
+    NSHighResolutionCapable: true
+  };
+
+  fs.writeFileSync(plistFile, require("plist").build(plistContents));
+
+  // Copy the bin folder over
+  util.copy(config.binPath, binaryDirectory);
+
+  // ...but move non-executables from the bin folder to the resources folder,
+  // but symlink in, so that the executables can pretend they are available
+
+  const filesToBeMoved = fs.readdirSync(binaryDirectory).filter(f => {
+    return f != bundleInfo.mainExecutable;
+  });
+
+  filesToBeMoved.forEach(file => {
+    console.log("Moving file: " + file);
+    const fileSrc = path.join(binaryDirectory, file);
+    const fileDest = path.join(resourcesDirectory, file);
+    console.log(`Moving file from ${fileSrc} to ${fileDest}.`);
+    fs.moveSync(fileSrc, fileDest);
+    const symlinkDest = path.join("../Resources", file);
+    console.log(`Symlinking ${symlinkDest} -> ${fileSrc}`);
+    fs.ensureSymlinkSync(symlinkDest, fileSrc);
+  });
+
+  console.log("Bundling dylibs...");
+
+  const executablePath = path.join(binaryDirectory, bundleInfo.mainExecutable);
+
+  // Run the 'dylibbundler' tool
+  util.shell(
+    `${config.macBundlerPath} -b -x "${executablePath}" -d "${frameworksDirectory}" -p "@executable_path/../Frameworks/" -cd`
+  );
+
+  // Bundle into tar package, if specified
+  if (config.bundleInfo.packages.indexOf("tar") >= 0) {
+    const tarDest = `${config.bundleInfo.bundleName}-darwin.tar.gz`;
+    util.shell(
+      `cd '${config.platformReleaseDir}' && tar -zcf '../${tarDest}' ${appName}`
+    );
+    console.log(`** Created tar package: ${tarDest}`);
+  }
+
+  // Create DMG package, if specified
+  if (config.bundleInfo.packages.indexOf("dmg") >= 0) {
+    const dmgTarget = config.bundleInfo.bundleName + ".dmg";
+    const spec = {
+      target: path.join(config.releaseDir, dmgTarget),
+      basepath: config.platformReleaseDir,
+      specification: {
+        title: config.bundleInfo.displayName,
+        background: config.bundleInfo.dmgBackground,
+        format: "ULFO",
+        window: {
+          size: {
+            width: 660,
+            height: 400
+          }
+        },
+        contents: [
+          {
+            x: 180,
+            y: 170,
+            type: "file",
+            path: appDirectory
+          },
+          {
+            x: 480,
+            y: 170,
+            type: "link",
+            path: "/Applications"
+          }
+        ]
+      }
+    };
+
+    await makeDmg(spec);
+    console.log("** Created DMG: " + dmgTarget);
+  }
+
+  console.log("OSX packaging complete!");
+};


### PR DESCRIPTION
Just tried `revery-packager`, so cool! 

The idiom, I believe (while scrolling through my `/Applications`-directory) is to use `.app` as the file-extension. Also adds `esy.lock`